### PR TITLE
Crosscompile build configs for Beaglebone Black and Raspperry Pi with Debian Stretch OS

### DIFF
--- a/build/config/X-Debian-Stretch-BBB
+++ b/build/config/X-Debian-Stretch-BBB
@@ -1,0 +1,74 @@
+#
+# X-Debian-Stretch-BBB
+#
+# Make settings for BeagleBone Black with Debian Stretch
+#
+#
+
+#
+# General Settings
+#
+LINKMODE           ?= SHARED
+TOOL               ?= arm-linux-gnueabihf
+POCO_TARGET_OSNAME  = Linux
+POCO_TARGET_OSARCH ?= armv7l
+ARCHFLAGS          ?= -mcpu=cortex-a8 -mfloat-abi=hard -mfpu=neon
+
+#
+# Define Tools
+#
+CC      = $(TOOL)-gcc
+CXX     = $(TOOL)-g++
+LINK    = $(CXX)
+LIB     = $(TOOL)-ar -cr
+RANLIB  = $(TOOL)-ranlib
+SHLIB   = $(CXX) -shared -Wl,-soname,$(notdir $@) -o $@
+SHLIBLN = $(POCO_BASE)/build/script/shlibln
+STRIP   = $(TOOL)-strip
+DEP     = $(POCO_BASE)/build/script/makedepend.gcc
+SHELL   = sh
+RM      = rm -rf
+CP      = cp
+MKDIR   = mkdir -p
+
+#
+# Extension for Shared Libraries
+#
+SHAREDLIBEXT     = .so.$(target_version)
+SHAREDLIBLINKEXT = .so
+
+#
+# Compiler and Linker Flags
+#
+CFLAGS          = $(ARCHFLAGS)
+CFLAGS32        =
+CFLAGS64        =
+CXXFLAGS        = -Wall -Wno-sign-compare $(ARCHFLAGS)
+CXXFLAGS32      =
+CXXFLAGS64      =
+LINKFLAGS       =
+LINKFLAGS32     =
+LINKFLAGS64     =
+STATICOPT_CC    =
+STATICOPT_CXX   =
+STATICOPT_LINK  = -static
+SHAREDOPT_CC    = -fPIC
+SHAREDOPT_CXX   = -fPIC
+SHAREDOPT_LINK  = -Wl,-rpath,$(LIBPATH)
+DEBUGOPT_CC     = -g -D_DEBUG
+DEBUGOPT_CXX    = -g -D_DEBUG
+DEBUGOPT_LINK   = -g
+RELEASEOPT_CC   = -O2 -DNDEBUG
+RELEASEOPT_CXX  = -O2 -DNDEBUG
+RELEASEOPT_LINK = -O2
+
+#
+# System Specific Flags
+#
+SYSFLAGS = -D_XOPEN_SOURCE=600 -D_REENTRANT -D_THREAD_SAFE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -DPOCO_HAVE_FD_EPOLL \
+	-DPOCO_HAVE_ADDRINFO -DPOCO_HAVE_LIBRESOLV
+
+#
+# System Specific Libraries
+#
+SYSLIBS  = -lpthread -ldl -lrt

--- a/build/config/X-Debian-Stretch-RPi
+++ b/build/config/X-Debian-Stretch-RPi
@@ -1,0 +1,74 @@
+#
+# X-Debian-Stretch-RPi
+#
+# Make settings for Raspberry Pi (2 or newer) Raspbian Stretch
+#
+#
+
+#
+# General Settings
+#
+LINKMODE           ?= SHARED
+TOOL               ?= arm-linux-gnueabihf
+POCO_TARGET_OSNAME  = Linux
+POCO_TARGET_OSARCH ?= armv7l
+ARCHFLAGS          ?= -march=armv7-a -mfloat-abi=hard -mfpu=neon-vfpv4
+
+#
+# Define Tools
+#
+CC      = $(TOOL)-gcc
+CXX     = $(TOOL)-g++
+LINK    = $(CXX)
+LIB     = $(TOOL)-ar -cr
+RANLIB  = $(TOOL)-ranlib
+SHLIB   = $(CXX) -shared -Wl,-soname,$(notdir $@) -o $@
+SHLIBLN = $(POCO_BASE)/build/script/shlibln
+STRIP   = $(TOOL)-strip
+DEP     = $(POCO_BASE)/build/script/makedepend.gcc
+SHELL   = sh
+RM      = rm -rf
+CP      = cp
+MKDIR   = mkdir -p
+
+#
+# Extension for Shared Libraries
+#
+SHAREDLIBEXT     = .so.$(target_version)
+SHAREDLIBLINKEXT = .so
+
+#
+# Compiler and Linker Flags
+#
+CFLAGS          = $(ARCHFLAGS)
+CFLAGS32        =
+CFLAGS64        =
+CXXFLAGS        = -Wall -Wno-sign-compare $(ARCHFLAGS)
+CXXFLAGS32      =
+CXXFLAGS64      =
+LINKFLAGS       =
+LINKFLAGS32     =
+LINKFLAGS64     =
+STATICOPT_CC    =
+STATICOPT_CXX   =
+STATICOPT_LINK  = -static
+SHAREDOPT_CC    = -fPIC
+SHAREDOPT_CXX   = -fPIC
+SHAREDOPT_LINK  = -Wl,-rpath,$(LIBPATH)
+DEBUGOPT_CC     = -g -D_DEBUG
+DEBUGOPT_CXX    = -g -D_DEBUG
+DEBUGOPT_LINK   = -g
+RELEASEOPT_CC   = -O2 -DNDEBUG
+RELEASEOPT_CXX  = -O2 -DNDEBUG
+RELEASEOPT_LINK = -O2
+
+#
+# System Specific Flags
+#
+SYSFLAGS = -D_XOPEN_SOURCE=600 -D_REENTRANT -D_THREAD_SAFE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -DPOCO_HAVE_FD_EPOLL \
+	-DPOCO_HAVE_ADDRINFO -DPOCO_HAVE_LIBRESOLV
+
+#
+# System Specific Libraries
+#
+SYSLIBS  = -lpthread -ldl -lrt


### PR DESCRIPTION
Copy build configs from macchina.io without c99 and c++11 flags

Setup build machine as described on macchina.io wiki:

https://github.com/macchina-io/macchina.io/wiki/Cross-Compiling-for-Raspberry-Pi-(Raspbian)-and-BeagleBone-Black-(Debian-Stretch)

and also install zlib:
`$ sudo apt-get install zlib1g-dev:armhf`